### PR TITLE
Fix formatting in Use section

### DIFF
--- a/src/templates/use.pug
+++ b/src/templates/use.pug
@@ -2,10 +2,12 @@
   1. #### Pick a service that includes Enketo
     
     Simply [pick a tool](/#tools) that has Enketo built-in. This is usually the best option.
+
   2. #### Run Enketo yourself
     
     Enketo is 100% free and [open source](https://github.com/enketo/enketo-express). Look into 
     [installing](primary.Use.Installation) it yourself and ask for support from other users in the [user forum](sites['enketo-user-forum']). Consider [funding](primary.About.Sponsors) Enketo's further development of new features and fixing of bugs.
+    
   3. #### Use a paid Enketo-only or custom service
     
     Consider paying for one of the [services](/services#saas) that run Enketo for you.


### PR DESCRIPTION
I noticed that only the first heading in [How to Use Enketo][1] was being rendered correctly. Adding whitespace before the other headings seemed to fix it.

- ### Before:

    <img width="958" alt="Screenshot 2023-04-25 at 13 45 18" src="https://user-images.githubusercontent.com/785939/234280375-a456f7fc-9445-4218-b2eb-8f598fcf8da1.png">

- ### After:

    <img width="958" alt="Screenshot 2023-04-25 at 13 45 39" src="https://user-images.githubusercontent.com/785939/234280474-8cf00283-6c4b-42c5-9ed1-89f0f394a943.png">

[1]: https://enketo.org/#use