### PR TITLE
changed: links to demo forms for when enke.to server shuts down

### DIFF
--- a/src/templates/samples.pug
+++ b/src/templates/samples.pug
@@ -8,55 +8,55 @@
             "title":"Widgets",
             "img": "/media/images/screenshots/widgets.png",
             "desc": "Showcases the different available widgets",
-            "live": "https://enke.to/x/widgets",
+            "live": "https://ee.kobotoolbox.org/x/8JGrcU96",
             "auth": "Multiple",
             "src": "https://docs.google.com/spreadsheet/ccc?key=0Al3Mw5sknZoPdEpPa29tamFCc1o2bmFVR3RaemlSRXc&usp=sharing"
           }, {
             "title":"Image Map",
             "img": "/media/images/screenshots/imgmap.png",
             "desc": "Image Map Demo",
-            "live": "https://enke.to/x/imgmap",
+            "live": "https://ee.kobotoolbox.org/x/YCz3",
             "auth": "Enketo LLC",
             "src": "https://docs.google.com/spreadsheets/d/1kXZ9IkWsc8iEXfN0Uosl8giJIBTf428dEBWNkhXXU3M/edit?usp=sharing"
           }, {
             "title": "Fatal Injury",
             "img": "/media/images/screenshots/fatal.png",
             "desc": "A form using the Grid Theme",
-            "live": "https://enke.to/x/fatal",
+            "live": "https://ee.kobotoolbox.org/x/2vBunTi4",
             "auth": "WHO-Ona"
           }, {
             "title": "Likert Scales",
             "img": "/media/images/screenshots/likert.png",
             "desc": "A form with Likert widgets to create a Likert scale",
-            "live": "https://enke.to/x/likert",
+            "live": "https://ee.kobotoolbox.org/x/HBEdtG0f",
             "auth": "Enketo LLC",
             "src": "https://docs.google.com/spreadsheets/d/11zTyKPbYYNG5rAwZRQlR6Tj6ox9A4O82vMmAU5EsQ60/edit?usp=sharing"
           }, {
             "title": "Draw widgets",
             "img": "/media/images/screenshots/draw.png",
             "desc": "A form with Draw and Signature widgets",
-            "live": "https://enke.to/x/draw",
+            "live": "https://ee.kobotoolbox.org/x/mugIQUer",
             "auth": "Enketo LLC",
             "src": "https://docs.google.com/spreadsheets/d/1Pw60xxOwKE5rHS2WkYGejfJ7knVVlKpGGVsPTp1Yqg0/edit?usp=sharing"
           }, {
             "title": "S.E.L.F. Study",
             "img": "/media/images/screenshots/SELF.png",
             "desc": "A form with complex skip logic and advanced features",
-            "live": "https://enke.to/x/self",
+            "live": "https://ee.kobotoolbox.org/x/ylDF1L9g",
             "auth": "Erwin Olario",
             "src": "https://docs.google.com/spreadsheet/ccc?key=0Al3Mw5sknZoPdDJUQW10YnFZRGRBWDR6SGNXUW1RVEE&usp=sharing"
           }, {
             "title":"Birds",
             "img": "/media/images/screenshots/birds.png",
             "desc": "A form using media labels",
-            "live": "https://enke.to/x/birds",
+            "live": "https://ee.kobotoolbox.org/x/LggNNYM1",
             "auth": "Unknown",
             "src": "https://docs.google.com/spreadsheets/d/1jsWB7685StKW_OW7YFgoLHHoSPE_xk6Tcf5UsHh5JJA/edit?usp=sharing"
           }, {
             "title":"Grid Theme Tutorial",
             "img": "/media/images/screenshots/grid.png",
             "desc": "Tutorial for Grid Theme",
-            "live": "https://enke.to/x/grid",
+            "live": "https://ee.kobotoolbox.org/x/n41GqUkf",
             "auth": "Enketo LLC",
             "src": "https://docs.google.com/spreadsheet/ccc?key=0Al3Mw5sknZoPdDhSVmhJX2NvOG44X1RadTA2RVRzSHc&usp=sharing"
           }


### PR DESCRIPTION
This may turn out to be a temporary replacement, but I shut down https://enke.to today, so we need some fix.